### PR TITLE
Fix wrong time complexity

### DIFF
--- a/C++/merge-k-sorted-lists.cpp
+++ b/C++/merge-k-sorted-lists.cpp
@@ -1,4 +1,4 @@
-// Time:  O(logk(n * k))
+// Time:  O(logk * n * k)
 // Space: O(1)
 
 /**

--- a/C++/merge-k-sorted-lists.cpp
+++ b/C++/merge-k-sorted-lists.cpp
@@ -1,4 +1,4 @@
-// Time:  O(n * k)
+// Time:  O(logk(n * k))
 // Space: O(1)
 
 /**

--- a/C++/merge-k-sorted-lists.cpp
+++ b/C++/merge-k-sorted-lists.cpp
@@ -1,4 +1,4 @@
-// Time:  O(n * logk)
+// Time:  O(n * k)
 // Space: O(1)
 
 /**

--- a/C++/merge-k-sorted-lists.cpp
+++ b/C++/merge-k-sorted-lists.cpp
@@ -1,4 +1,4 @@
-// Time:  O(logk * n * k)
+// Time:  O(n * k * logk)
 // Space: O(1)
 
 /**

--- a/C++/merge-k-sorted-lists.cpp
+++ b/C++/merge-k-sorted-lists.cpp
@@ -1,4 +1,4 @@
-// Time:  O(n * k * logk)
+// Time:  O(n * logk), n is the length of the result list.
 // Space: O(1)
 
 /**


### PR DESCRIPTION
If we merge lists two by two
The time it cost will be
n * ( <img src="http://latex.codecogs.com/gif.latex?%5Cdfrac%7Bk%7D%7B2%7D" /> + <img src="http://latex.codecogs.com/gif.latex?%5Cdfrac%7Bk%7D%7B4%7D" /> + ... <img src="http://latex.codecogs.com/gif.latex?%5Cdfrac%7Bk%7D%7Bk%7D" /> )
As a result, the time complexity should be O(n * k)