### PR TITLE
19. Remove Nth Node From End of List. Java

### DIFF
--- a/Java/src/net/kenyang/algorithm/RemoveTheNthNodeFromList.java
+++ b/Java/src/net/kenyang/algorithm/RemoveTheNthNodeFromList.java
@@ -1,0 +1,34 @@
+public class RemoveTheNthNodeFromList {
+
+    /**
+     * Definition for singly-linked list.
+     * public class ListNode {
+     *     int val;
+     *     ListNode next;
+     *     ListNode() {}
+     *     ListNode(int val) { this.val = val; }
+     *     ListNode(int val, ListNode next) { this.val = val; this.next = next; }
+     * }
+     */
+    public void remove_curr_node(ListNode node){
+        if (node.next != null)
+            node.next = node.next.next;
+    }
+    public ListNode removeNthFromEnd(ListNode head, int n) {
+        ListNode beforeList = new ListNode(0);
+        beforeList.next = head;
+        int size = 0;
+        head = beforeList;
+        ListNode tail = beforeList;
+        while (size < n) {
+            head = head.next;
+            size ++;
+        }
+        while (head.next != null) {
+            head = head.next;
+            tail = tail.next;
+        }
+        remove_curr_node(tail);
+        return beforeList.next;
+    }
+}


### PR DESCRIPTION
Given the head of a linked list, remove the nth node from the end of the list and return its head.
Passed in Leetecode:
Runtime: 0 ms, faster than 100.00% of Java online submissions for Remove Nth Node From End of List.
Memory Usage: 36.9 MB, less than 7.76% of Java online submissions for Remove Nth Node From End of List.