### PR TITLE
713. Subarray Product Less Than K. Java

### DIFF
--- a/Java/src/net/kenyang/algorithm/SubArrayProduct
+++ b/Java/src/net/kenyang/algorithm/SubArrayProduct
@@ -1,0 +1,19 @@
+public class SubArrayProduct {
+    public int numSubarrayProductLessThanK(int[] nums, int k) {
+        int counter_less_than_k = 0;
+        int product = 1;
+        int head = 0, tail = 0;
+
+        while (head < nums.length && tail <= head) {
+            product *= nums[head];
+
+            while (product >= k && tail <= head) {
+                product = product / nums[tail];
+                tail++;
+            }
+            counter_less_than_k += head - tail + 1;
+            head++;
+        }
+        return counter_less_than_k;
+    }
+}


### PR DESCRIPTION
Passed Leetecode:
Runtime: 9 ms, faster than 17.54% of Java online submissions for Subarray Product Less Than K.
Memory Usage: 105.6 MB, less than 88.89% of Java online submissions for Subarray Product Less Than K.