### PR TITLE
Update maximum-score-from-performing-multiplication-operations.py

### DIFF
--- a/Python/maximum-score-from-performing-multiplication-operations.py
+++ b/Python/maximum-score-from-performing-multiplication-operations.py
@@ -10,5 +10,5 @@ class Solution(object):
         """
         dp = [0]*(len(multipliers)+1)
         for l, m in enumerate(reversed(multipliers), start=len(nums)-len(multipliers)):
-            dp = [max(m*nums[i]+dp[i+1], m*nums[i+l]+dp[i]) for i in xrange(len(dp)-1)]
+            dp = [max(m*nums[i]+dp[i+1], m*nums[i+l]+dp[i]) for i in range(len(dp)-1)]
         return dp[0]


### PR DESCRIPTION
The Python "NameError: name 'xrange' is not defined" when we use the xrange() function in a Python 3 codebase. To solve the error, use the range() function instead, because xrange was renamed to range in Python 3.