### PR TITLE
Rotting Oranges in PHP

### DIFF
--- a/PHP/rotting-oranges.php
+++ b/PHP/rotting-oranges.php
@@ -1,0 +1,59 @@
+/*
+    Time: O(n*m)
+    Space: O(n*m)
+ */
+
+class Solution {
+
+/**
+ * @param Integer[][] $grid
+ * @return Integer
+ */
+
+    public function orangesRotting($grid) {
+        $dir = [-1, 0, 1, 0, -1]; // used for finding all 4 adjacent coordinates
+        
+        $m = count($grid);
+        $n = count($grid[0]);
+        
+        $q = new SplQueue();
+        $fresh = 0; // To keep track of all fresh oranges left
+        for ($i = 0; $i < $m; $i++) {
+            for ($j = 0; $j < $n; $j++) {
+                if ($grid[$i][$j] == 2) {
+                    $q->enqueue([$i, $j]);
+                }
+                if ($grid[$i][$j] == 1) {
+                    $fresh++;
+                }
+            }
+        }
+        
+        $ans = -1; // initialised to -1 since after each step we increment the time by 1 and initially all rotten oranges started at 0.
+        while (!$q->isEmpty()) {
+            $sz = $q->count();
+            while ($sz--) {
+                $p = $q->dequeue();
+                for ($i = 0; $i < 4; $i++) {
+                    $r = $p[0] + $dir[$i];
+                    $c = $p[1] + $dir[$i + 1];
+                    if ($r >= 0 && $r < $m && $c >= 0 && $c < $n && $grid[$r][$c] == 1) {
+                        $grid[$r][$c] = 2;
+                        $q->enqueue([$r, $c]);
+                        $fresh--; // decrement by 1 for each fresh orange that now is rotten
+                    }
+                }
+            }
+            $ans++; // incremented after each minute passes
+        }
+        
+        if ($fresh > 0) {
+            return -1; // if fresh > 0 that means there are fresh oranges left
+        }
+        if ($ans == -1) {
+            return 0; // we initialised with -1, so if there were no oranges it'd take 0 mins.
+        }
+        
+        return $ans;
+    }
+}


### PR DESCRIPTION
To implement a rotten oranges simulation in PHP, you can follow these steps:

> Create a grid: Start by creating a 2-dimensional array to represent the grid of oranges. Each element in the array will represent the state of an orange, where 0 represents a fresh orange and 1 represents a rotten orange.

> Define the adjacent directions: Since a rotten orange can affect its adjacent oranges, define an array of possible adjacent directions (up, down, left, right).

> Create a queue: Initialize an empty queue that will be used to store the coordinates of the rotten oranges.

> Initialize the queue with initial rotten oranges: Iterate through the grid and enqueue the coordinates of the initial rotten oranges into the queue.

> Perform BFS traversal: Start a Breadth-First Search (BFS) traversal to simulate the rotting process. While the queue is not empty, dequeue the coordinates of a rotten orange, check its adjacent oranges, and enqueue any fresh oranges that can be affected.

> Check for any remaining fresh oranges: After the BFS traversal, iterate through the grid to check if any fresh oranges are left. If any fresh oranges are found, it means they were not affected by the rotten oranges.