### PR TITLE
Adding support case sensitive regex syntax in MySQL valid email queries

### DIFF
--- a/MySQL/find-users-with-valid-e-mails.sql
+++ b/MySQL/find-users-with-valid-e-mails.sql
@@ -3,4 +3,4 @@
 
 SELECT * 
 FROM   users AS u 
-WHERE  u.mail REGEXP '^[a-zA-Z][a-zA-Z0-9._-]*@leetcode.com$'; 
+WHERE REGEXP_LIKE(u.mail, '^[a-zA-Z][a-zA-Z0-9._-]*@leetcode.com$', 'c');

--- a/MySQL/find-valid-emails.sql
+++ b/MySQL/find-valid-emails.sql
@@ -4,5 +4,5 @@
 # regular expression
 SELECT user_id, email 
 FROM users
-WHERE email REGEXP '^[a-zA-Z0-9_]+@[a-zA-Z]+\.com$'
+WHERE REGEXP_LIKE(email, '^[a-zA-Z0-9_]+@[a-zA-Z]+\.com$', 'c')
 ORDER BY 1;


### PR DESCRIPTION
LeetCode 1517 requires a case-sensitive solution. REGEXP matches case insensitively.
According to  MySQL 8.0 Reference (https://dev.mysql.com/doc/refman/8.0/en/regexp.html#function_regexp-like), REGEXP_LIKE with an optional argument can be passed to match case sensitively.


FYI,
LeetCode 1517 does not allow the case-insensitive solution to pass the test cases.